### PR TITLE
Fix price parsing regex

### DIFF
--- a/utils/test_text.py
+++ b/utils/test_text.py
@@ -24,3 +24,7 @@ def test_extract_decimal_prices_many() -> None:
         Decimal(122.00),
         Decimal(100.00),
     ]
+
+
+def test_extract_decimal_prices_without_commas() -> None:
+    assert extract_decimal_prices("$2110.00") == [Decimal(2110.00)]

--- a/utils/text.py
+++ b/utils/text.py
@@ -4,7 +4,10 @@ from decimal import Decimal
 
 def extract_decimal_prices(text: str) -> list[Decimal]:
     prices: list[Decimal] = []
-    matches = re.findall(r"\$(\d{1,3}(?:,\d{3})*(?:\.\d{2}))?", text)
+    matches = re.findall(
+        r"\$((?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d{2}))",
+        text,
+    )
     for match in matches:
         prices.append(Decimal(match.replace(",", "")))
 


### PR DESCRIPTION
## Summary
- fix regex for extracting decimal prices to support four-digit numbers without commas
- test extraction for amounts without commas

## Testing
- `pytest utils/test_text.py -q --confcutdir=utils`

------
https://chatgpt.com/codex/tasks/task_e_68663ba9d2e0832b9fba5e1cad1f4b75