### PR TITLE
Fix typos and improve sorting tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ from webdriver_factory import get_driver
 
 @pytest.fixture(scope="module")
 def driver() -> Generator[WebDriver, None, None]:
-    """Returns initialized WedDriver instance."""
+    """Returns initialized WebDriver instance."""
     drv = get_driver()
     yield drv
     drv.quit()

--- a/tests/opencart/test_search.py
+++ b/tests/opencart/test_search.py
@@ -1,20 +1,30 @@
+import pytest
+
+
 def test_correct_count(search_page) -> None:
     results = search_page.get_search_results()
 
     assert len(results) == 12
 
 
-def test_sort_high_low(search_page) -> None:
-    search_page.sort_price_high_low()
+@pytest.mark.parametrize(
+    "sort_method, attr, reverse",
+    [
+        ("sort_price_low_high", "price", False),
+        ("sort_price_high_low", "price", True),
+        ("sort_name_az", "name", False),
+        ("sort_name_za", "name", True),
+    ],
+)
+def test_sorting(search_page, sort_method, attr, reverse) -> None:
+    getattr(search_page, sort_method)()
 
     products = search_page.get_search_results()
-    prices = [product.price for product in products]
-    assert prices == sorted(prices, reverse=True)
+    values = [getattr(p, attr) for p in products]
 
+    if attr == "name":
+        sorted_values = sorted(values, key=str.casefold, reverse=reverse)
+    else:
+        sorted_values = sorted(values, reverse=reverse)
 
-def test_sort_name_za(search_page) -> None:
-    search_page.sort_name_za()
-
-    products = search_page.get_search_results()
-    names = [product.name for product in products]
-    assert names == sorted(names, key=str.casefold, reverse=True)
+    assert values == sorted_values

--- a/utils/autowait.py
+++ b/utils/autowait.py
@@ -50,7 +50,7 @@ def patched_send_keys_factory(timeout: float):
 
     def patched_send_keys(self, *args, **kwargs):
         """
-        Patches the WebElement's click method to wait for the element to be clickable.
+        Patches the WebElement's send_keys method to wait for the element to be clickable.
         Args:
             self: WebElement object.
         """

--- a/webdriver_factory.py
+++ b/webdriver_factory.py
@@ -76,7 +76,7 @@ def get_safari_driver() -> WebDriver:
 def get_remote_driver() -> WebDriver:
     res = get_window_resolution()
     options = Options()
-    options.add_argument(f"--window-size={res['width']}, {res['height']}")
+    options.add_argument(f"--window-size={res['width']},{res['height']}")
     options.add_argument("--headless")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-smooth-scrolling")


### PR DESCRIPTION
## Summary
- correct WebDriver typo in the driver fixture
- remove space in remote driver window-size option
- fix documentation for patched_send_keys
- add parameterized sorting test covering all options

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68663baae760832bba76b260020dedb5