### PR TITLE
Fix GitHub Action for artifact upload

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -51,7 +51,8 @@ jobs:
 
       # Upload test reports
       - name: Upload test reports
-        uses: actions/upload-artifact@v3
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: test-reports/**


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to v4 in GitHub workflow
- ensure test reports always upload even if tests fail

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_686762a26d7c832ba799955c9d0562d0